### PR TITLE
build!: bump mdib dsl lib version in order to correctly generate ieee…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 somda-repository-collection = "2.0.0"
-mdib-dsl = "1.5.0-SNAPSHOT+85"
+mdib-dsl = "1.5.0-SNAPSHOT+97"
 
 [libraries]
 org-somda-mdib-dsl = { module = "org.somda.dsl.biceps:mdib-dsl", version.ref = "mdib-dsl"}


### PR DESCRIPTION
… public codes (previously missed urn:oid: prefix).