### PR TITLE
build: #1 bump mdib dsl lib version in order to correctly generate ie…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Each section shall contain a list of action items of the following format: `<bri
 
 ## [Unreleased]
 
+## [2.2.1] - 2025-04-08
+
+### Fixed
+
+- IEEE public codes now contain a valid coding system URI. ([#1](https://github.com/ornet-ev/plug-a-thon-testing/issues/1))
+
 ## [2.2.0] - 2025-02-27
 
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 somda-repository-collection = "2.0.0"
-mdib-dsl = "1.5.0-SNAPSHOT+85"
+mdib-dsl = "1.5.0-SNAPSHOT+97"
 
 [libraries]
 org-somda-mdib-dsl = { module = "org.somda.dsl.biceps:mdib-dsl", version.ref = "mdib-dsl"}


### PR DESCRIPTION
…ee public codes (previously missed urn:oid: prefix).